### PR TITLE
DP-6444 - Fix DP-6444 BAG TypeError: 'NoneType' object is not callable

### DIFF
--- a/bag/datasets/brk/views.py
+++ b/bag/datasets/brk/views.py
@@ -354,7 +354,7 @@ class KadastraalObjectViewSet(DatapuntViewSet):
     lookup_value_regex = '[^/]+'
 
     def get_serializer_class(self):
-        if self.action == 'list':
+        if self.action == 'list' or self.action is None:
             return serializers.KadastraalObject
 
         elif self.action == 'retrieve':


### PR DESCRIPTION
This happens when a HEAD request is made. The the action parameter is None

The stacktrace was :

TypeError: 'NoneType' object is not callable
  File "django/core/handlers/exception.py", line 35, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 128, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 126, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "rest_framework/viewsets.py", line 103, in view
    return self.dispatch(request, *args, **kwargs)
  File "rest_framework/views.py", line 483, in dispatch
    response = self.handle_exception(exc)
  File "rest_framework/views.py", line 443, in handle_exception
    self.raise_uncaught_exception(exc)
  File "rest_framework/views.py", line 480, in dispatch
    response = handler(request, *args, **kwargs)
  File "rest_framework/mixins.py", line 44, in list
    serializer = self.get_serializer(page, many=True)
  File "rest_framework/generics.py", line 112, in get_serializer
    return serializer_class(*args, **kwargs)