### PR TITLE
DP-6460 -  Check if adresseerbaar_object exists before using it.

### DIFF
--- a/bag/datasets/bag/models.py
+++ b/bag/datasets/bag/models.py
@@ -620,7 +620,7 @@ class Nummeraanduiding(mixins.GeldigheidMixin, mixins.MutatieGebruikerMixin,
     @property
     def vbo_status(self):
         a = self.adresseerbaar_object
-        return a.status
+        return a.status if a else None
 
     @property
     def buurt(self):


### PR DESCRIPTION
For URL https://acc.api.data.amsterdam.nl/bag/nummeraanduiding/?postcode=1015ML&huisnummer=76

this will prevent server 500 error

See : https://sentry.datapunt.amsterdam.nl/sentry/datapunt-apis-prod/issues/90295/