### PR TITLE
DP-6418 - Extend search and typeahead with search for landelijk_id

### DIFF
--- a/bag/bag/settings/settings.py
+++ b/bag/bag/settings/settings.py
@@ -90,7 +90,7 @@ ELASTIC_INDICES = {
     'BRK_OBJECT': 'brk_object',
     'BRK_SUBJECT': 'brk_subject',
     'NUMMERAANDUIDING': 'nummeraanduiding',
-    'LANDELIJK_ID': 'landelijk_id',
+    'BAG_PAND': 'bag_pand',
 }
 
 TESTING = len(sys.argv) > 1 and sys.argv[1] == 'test'

--- a/bag/bag_commands/management/commands/elastic_indices.py
+++ b/bag/bag_commands/management/commands/elastic_indices.py
@@ -10,13 +10,14 @@ from batch import batch
 
 
 class Command(BaseCommand):
-    ordered = ['bag', 'brk', 'wkpb', 'gebieden']
+    ordered = ['bag', 'brk', 'wkpb', 'gebieden', 'pand']
 
     indexes = {
         'bag': [datasets.bag.batch.BuildIndexBagJob],
         'brk': [datasets.brk.batch.BuildIndexKadasterJob],
         'wkpb': [],
         'gebieden': [datasets.bag.batch.IndexGebiedenJob],
+        'pand': [datasets.bag.batch.IndexPandJob],
     }
 
     delete_indexes = {
@@ -24,6 +25,7 @@ class Command(BaseCommand):
         'brk': [datasets.brk.batch.DeleteIndexKadasterJob],
         'wkpb': [],  # has no elastic index
         'gebieden': [datasets.bag.batch.DeleteIndexGebiedJob],
+        'pand': [datasets.bag.batch.DeleteIndexPandJob],
     }
 
     def add_arguments(self, parser):

--- a/bag/datasets/bag/batch.py
+++ b/bag/datasets/bag/batch.py
@@ -1,6 +1,4 @@
 # Python
-# import datetime
-# import json
 import logging
 import os
 # Packages
@@ -9,7 +7,6 @@ from django.contrib.gis.geos import Point
 from django.db import connection
 from django.db.models import Value, CharField
 from django.utils.text import slugify
-# import requests
 # Project
 from search import index
 from batch import batch
@@ -1460,9 +1457,9 @@ class DeleteNummerAanduidingIndexTask(index.DeleteIndexTask):
     doc_types = [documents.Nummeraanduiding]
 
 
-class DeleteLandelijkIdTask(index.DeleteIndexTask):
-    index = settings.ELASTIC_INDICES['LANDELIJK_ID']
-    doc_types = [documents.LandelijkId]
+class DeletePandTask(index.DeleteIndexTask):
+    index = settings.ELASTIC_INDICES['BAG_PAND']
+    doc_types = [documents.Pand]
 
 
 class IndexLigplaatsTask(index.ImportIndexTask):
@@ -1593,58 +1590,13 @@ class IndexNummerAanduidingTask(index.ImportIndexTask):
         return documents.from_nummeraanduiding_ruimte(obj)
 
 
-class IndexLandelijkIdNummeraanduidingTask(index.ImportIndexTask):
-    name = "index landelijk id met nummeraanduiding"
+class IndexPandTask(index.ImportIndexTask):
+    name = "index pand"
 
-    queryset = models.Nummeraanduiding.objects.only('landelijk_id')
-
-    def convert(self, obj):
-        return documents.from_landelijk_id(obj, 'nummeraanduiding')
-
-
-class IndexLandelijkIdOpenbareRuimteTask(index.ImportIndexTask):
-    name = "index landelijk id met openbare ruimte"
-
-    queryset = models.OpenbareRuimte.objects.only('landelijk_id')
+    queryset = models.Pand.objects.only('landelijk_id', 'pandnaam')
 
     def convert(self, obj):
-        return documents.from_landelijk_id(obj, 'openbare_ruimte')
-
-
-class IndexLandelijkIdLigplaatsTask(index.ImportIndexTask):
-    name = "index landelijk id met ligplaats"
-
-    queryset = models.Ligplaats.objects.only('landelijk_id')
-
-    def convert(self, obj):
-        return documents.from_landelijk_id(obj, 'ligplaats')
-
-
-class IndexLandelijkIdStandplaatsTask(index.ImportIndexTask):
-    name = "index landelijk id met standplaats"
-
-    queryset = models.Standplaats.objects.only('landelijk_id')
-
-    def convert(self, obj):
-        return documents.from_landelijk_id(obj, 'standplaats')
-
-
-class IndexLandelijkIdPandTask(index.ImportIndexTask):
-    name = "index landelijk id met pand"
-
-    queryset = models.Pand.objects.only('landelijk_id')
-
-    def convert(self, obj):
-        return documents.from_landelijk_id(obj, 'pand')
-
-
-class IndexLandelijkIdVerblijfsObjectTask(index.ImportIndexTask):
-    name = "index landelijk id met verblijfsobject"
-
-    queryset = models.Verblijfsobject.objects.only('landelijk_id')
-
-    def convert(self, obj):
-        return documents.from_landelijk_id(obj, 'verblijfsobject')
+        return documents.from_pand(obj)
 
 
 class IndexBouwblokTask(index.ImportIndexTask):
@@ -2241,13 +2193,6 @@ class IndexBagJob(object):
         return [
             DeleteNummerAanduidingIndexTask(),
             IndexNummerAanduidingTask(),
-            DeleteLandelijkIdTask(),
-            IndexLandelijkIdNummeraanduidingTask(),
-            IndexLandelijkIdOpenbareRuimteTask(),
-            IndexLandelijkIdLigplaatsTask(),
-            IndexLandelijkIdStandplaatsTask(),
-            IndexLandelijkIdPandTask(),
-            IndexLandelijkIdVerblijfsObjectTask(),
         ]
 
 
@@ -2257,12 +2202,7 @@ class BuildIndexBagJob(object):
     def tasks(self):
         return [
             IndexNummerAanduidingTask(),
-            IndexLandelijkIdNummeraanduidingTask(),
-            IndexLandelijkIdOpenbareRuimteTask(),
-            IndexLandelijkIdLigplaatsTask(),
-            IndexLandelijkIdStandplaatsTask(),
-            IndexLandelijkIdPandTask(),
-            IndexLandelijkIdVerblijfsObjectTask(),
+            IndexPandTask(),
         ]
 
 
@@ -2273,7 +2213,36 @@ class DeleteIndexBagJob(object):
     def tasks(self):
         return [
             DeleteNummerAanduidingIndexTask(),
-            DeleteLandelijkIdTask(),
+            DeletePandTask(),
+        ]
+
+
+class IndexPandJob(object):
+    name = "Delete and Fill Pand search-index"
+
+    def tasks(self):
+        return [
+            DeletePandTask(),
+            IndexPandTask(),
+        ]
+
+
+class BuildIndexPandJob(object):
+    name = "Fill Pand search-index"
+
+    def tasks(self):
+        return [
+            IndexPandTask(),
+        ]
+
+
+class DeleteIndexPandJob(object):
+
+    name = "Delete Pand related indexes"
+
+    def tasks(self):
+        return [
+            DeletePandTask(),
         ]
 
 

--- a/bag/datasets/bag/tests/factories.py
+++ b/bag/datasets/bag/tests/factories.py
@@ -156,6 +156,7 @@ class PandFactory(factory.DjangoModelFactory):
 
     id = fuzzy.FuzzyText(length=14, chars=string.digits)
     landelijk_id = fuzzy.FuzzyText(length=16, chars=string.digits)
+    pandnaam = fuzzy.FuzzyText(length=20)
     bouwblok = factory.SubFactory(BouwblokFactory)
 
 

--- a/bag/datasets/generic/rest.py
+++ b/bag/datasets/generic/rest.py
@@ -2,8 +2,6 @@
 from collections import OrderedDict
 import json
 # Packages
-from urllib.parse import urlsplit, parse_qs, urlencode, urlunsplit
-
 from django.conf import settings
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import renderers, serializers
@@ -173,15 +171,15 @@ class RelatedSummaryField(serializers.Field):
             # if not filter_name.endswith('__id'):
             parent_pk = landelijk_id
 
-        scheme, netloc, path, query_string, fragment = urlsplit(url)
-        query_params = parse_qs(query_string)
-        query_params[filter_name] = [parent_pk]
-        new_query_string = urlencode(query_params, doseq=True)
-        href = urlunsplit((scheme, netloc, path, new_query_string, fragment))
-
+ #       scheme, netloc, path, query_string, fragment = urlsplit(url)
+ #       query_params = parse_qs(query_string)
+ #       query_params[filter_name] = [parent_pk]
+ #       new_query_string = urlencode(query_params, doseq=True)
+ #       href = urlunsplit((scheme, netloc, path, new_query_string, fragment))
+        separator = '&' if '?' in url else '?'
         return {
             'count': count,
-            'href': href,
+             'href': "{}{}{}={}".format(url, separator, filter_name, parent_pk),
         }
 
 

--- a/bag/search/analyzers.py
+++ b/bag/search/analyzers.py
@@ -97,6 +97,13 @@ lowercase = analysis.normalizer(
     filter=['lowercase']
 )
 
+strip_zero = analysis.CustomCharFilter(
+    "strip_zero",
+    builtin_type="pattern_replace",
+    pattern="^0+(.*)",
+    replacement="$1"
+)
+
 ####################################
 #           Analyzers              #
 ####################################
@@ -217,3 +224,10 @@ kad_obj_aanduiding_keyword = es.analyzer(
         token_chars=['letter', 'digit']),
     filter=['lowercase']
 )
+
+
+nozero = es.analyzer(
+    'nozero',
+    tokenizer='standard',
+    filter=[edge_ngram_filter],
+    char_filter=[strip_zero])

--- a/bag/search/query_analyzer.py
+++ b/bag/search/query_analyzer.py
@@ -337,7 +337,6 @@ class QueryAnalyzer(object):
     def get_landelijk_id(self) -> str:
         assert self.is_landelijk_id_prefix()
 
-        # strip leading zeros from query. All the landelijk id's have
-        # been indexed without leading zero's
+        # strip leading zeros from query. Match against landelijk_if__nozero
         return self.query.lstrip('0')
 

--- a/bag/search/tests/fill_elastic.py
+++ b/bag/search/tests/fill_elastic.py
@@ -12,13 +12,13 @@ import datasets.brk.batch
 from datasets.brk.tests import factories as brk_factories
 
 
-def load_docs():
+def load_docs(cls):
 
     bag_factories.StadsdeelFactory(
         id='test_query',
         naam='Centrum')
 
-    bag_factories.OpenbareRuimteFactory.create(
+    cls.prinsengracht = bag_factories.OpenbareRuimteFactory.create(
         naam="Prinsengracht", type='02', landelijk_id='0123456789012345')
 
     # Create brug objects
@@ -34,7 +34,7 @@ def load_docs():
     anjeliersstraat = bag_factories.OpenbareRuimteFactory.create(
         naam="Anjeliersstraat", type='01')
 
-    bag_factories.NummeraanduidingFactory.create(
+    cls.na = bag_factories.NummeraanduidingFactory.create(
         openbare_ruimte=anjeliersstraat, huisnummer=11, huisletter='A',
         type='01',
         landelijk_id='5432109876543210',
@@ -117,12 +117,16 @@ def load_docs():
         woonadres=adres
     )
 
+    cls.pand1 = bag_factories.PandFactory.create()
+
     batch.execute(datasets.bag.batch.DeleteIndexBagJob())
     batch.execute(datasets.bag.batch.DeleteIndexGebiedJob())
+    batch.execute(datasets.bag.batch.DeleteIndexPandJob())
     batch.execute(datasets.brk.batch.DeleteIndexKadasterJob())
 
     batch.execute(datasets.bag.batch.IndexBagJob())
     batch.execute(datasets.bag.batch.IndexGebiedenJob())
+    batch.execute(datasets.bag.batch.IndexPandJob())
     batch.execute(datasets.brk.batch.IndexKadasterJob())
 
     es = Elasticsearch(hosts=settings.ELASTIC_SEARCH_HOSTS)

--- a/bag/search/tests/test_aanduidingen_query.py
+++ b/bag/search/tests/test_aanduidingen_query.py
@@ -82,7 +82,7 @@ class SubjectSearchTest(APITestCase):
             openbare_ruimte=nen_straat
         )
 
-        bag_factories.NummeraanduidingFactory.create(
+        cls.na1 = bag_factories.NummeraanduidingFactory.create(
             huisnummer=29,
             huisletter='H',
             huisnummer_toevoeging=17,
@@ -221,3 +221,23 @@ class SubjectSearchTest(APITestCase):
 
         self.assertEqual(
             response.data['results'][0]['adres'], "Koningin Wilhelminaplein 122B-1A")
+
+    def test_query_landelijk_id(self):
+        landelijk_id =  self.na1.landelijk_id.lstrip('0')[0:12]
+        response = self.client.get(
+            "/atlas/search/adres/", {'q': landelijk_id})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('results', response.data)
+        self.assertIn('count', response.data)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['landelijk_id'], self.na1.landelijk_id)
+
+    def test_query_addresseerbaar_object_id_id(self):
+        adresseerbaar_object_id = self.na1.verblijfsobject.landelijk_id
+        response = self.client.get(
+            "/atlas/search/adres/", {'q': adresseerbaar_object_id})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('results', response.data)
+        self.assertIn('count', response.data)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['adresseerbaar_object_id'], adresseerbaar_object_id )

--- a/bag/search/tests/test_pand.py
+++ b/bag/search/tests/test_pand.py
@@ -1,0 +1,38 @@
+from rest_framework.test import APITestCase
+# Project
+from batch import batch
+import datasets.bag.batch
+from datasets.bag.tests import factories as bag_factories
+import datasets.brk.batch
+
+
+class SubjectSearchTest(APITestCase):
+
+    formats = [
+        ('api', 'text/html; charset=utf-8'),
+        ('json', 'application/json'),
+        ('xml', 'application/xml; charset=utf-8'),
+        ('csv', 'text/csv; charset=utf-8'),
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.pand = bag_factories.PandFactory.create()
+        batch.execute(datasets.bag.batch.DeleteIndexPandJob())
+        batch.execute(datasets.bag.batch.IndexPandJob())
+
+    def test_search_pand_landelijk_id(self):
+        q = self.pand.landelijk_id.strip('0')[0:6]
+        response = self.client.get('/atlas/search/pand/', {'q': q})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['landelijk_id'], self.pand.landelijk_id)
+
+    def test_search_pand_pandnaam(self):
+        q = self.pand.pandnaam.strip('0')[0:6]
+        response = self.client.get('/atlas/search/pand/', {'q': q})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['pandnaam'], self.pand.pandnaam)

--- a/bag/search/tests/test_query.py
+++ b/bag/search/tests/test_query.py
@@ -18,7 +18,7 @@ class QueryTest(APITransactionTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        load_docs()
+        load_docs(cls)
 
     def test_openbare_ruimte(self):
         response = self.client.get(
@@ -151,15 +151,38 @@ class QueryTest(APITransactionTestCase):
 
         self.assertIn("RN35", str(response.data))
 
-    def test_search_landelijk_id_pand(self):
-        q = '12345678'
-        res = self.client.get(f'/atlas/search/landelijk_id/?q={q}')
-        self.assertEquals(200, res.status_code)
-        self.assertEquals('0123456789012345', res.data['results'][0]['landelijk_id'])
-        self.assertEquals('openbare_ruimte', res.data['results'][0]['subtype'])
-
     def test_typeahead_landelijk_id_na(self):
-        q = '543210987'
+        q = self.na.landelijk_id[0:9]
+        vbo_id = self.na.verblijfsobject.id
         res = self.client.get(f'/atlas/typeahead/bag/?q={q}')
         self.assertEquals(200, res.status_code)
-        self.assertEquals('bag/nummeraanduiding/5432109876543210/', res.data[0]['content'][0]['uri'])
+        self.assertEquals(f'bag/verblijfsobject/{vbo_id}/', res.data[0]['content'][0]['uri'])
+
+    def test_typeahead_adresseerbaar_object_id_na(self):
+        adresseerbaar_object_id = self.na.verblijfsobject.landelijk_id
+        q = adresseerbaar_object_id.lstrip('0')[0:9]
+        vbo_id = self.na.verblijfsobject.id
+        res = self.client.get(f'/atlas/typeahead/bag/?q={q}')
+        self.assertEquals(200, res.status_code)
+        self.assertEquals(f'bag/verblijfsobject/{vbo_id}/', res.data[0]['content'][0]['uri'])
+
+    def test_typeahead_opr_landelijk_id(self):
+        q = self.prinsengracht.landelijk_id[0:6]
+        opr_id = self.prinsengracht.id
+        res = self.client.get(f'/atlas/typeahead/gebieden/?q={q}')
+        self.assertEquals(200, res.status_code)
+        self.assertEquals(f'bag/openbareruimte/{opr_id}/', res.data[0]['content'][0]['uri'])
+
+    def test_typeahead_pand_landelijk_id(self):
+        q = self.pand1.landelijk_id[0:9]
+        res = self.client.get(f'/atlas/typeahead/bag/?q={q}')
+        self.assertEquals(200, res.status_code)
+        self.assertEquals(f'bag/pand/{self.pand1.id}/', res.data[0]['content'][0]['uri'])
+
+    # Add if pand_naam search was added to bag typeahead endpoint
+    # def test_typeahead_pand_pandnaam(self):
+    #     q = self.pand1.pandnaam[0:6]
+    #     res = self.client.get(f'/atlas/typeahead/bag/?q={q}')
+    #     self.assertEquals(200, res.status_code)
+    #     self.assertEquals(f'bag/pand/{self.pand1.id}/', res.data[0]['content'][0]['uri'])
+

--- a/bag/search/tests/test_random_search.py
+++ b/bag/search/tests/test_random_search.py
@@ -15,7 +15,7 @@ class RandomShitTest(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        load_docs()
+        load_docs(cls)
 
     def test_random_shit_typeahead(self):
         """

--- a/bag/search/urls.py
+++ b/bag/search/urls.py
@@ -214,6 +214,6 @@ bag_search.register(
     r'openbareruimte',
     views.SearchOpenbareRuimteViewSet, base_name='search/openbareruimte')
 bag_search.register(
-    r'landelijk_id',
-    views.SearchLandelijkIdViewSet, base_name='search/landelijk_id')
+    r'pand',
+    views.SearchPandViewSet, base_name='search/pand')
 


### PR DESCRIPTION
The landelijk_id , adresseerbaar_object_id for Nummeraanduiding was added to the existing
nummeraanduiding and gebieden index.

For pand a new index was added.

The typeahead for pand  was added to typeahead/bag, but for search a new bag/search
endpoint was added