### PR TITLE
DP-6675 - If for a nummeraanduiding the link to verblijfsobject, ligp…

### DIFF
--- a/bag/search/views.py
+++ b/bag/search/views.py
@@ -319,6 +319,9 @@ def _get_url(request, hit):
 
     if detail_type in ('ligplaats', 'standplaats', 'verblijfsobject'):
         pk = _get_doc_attr(hit, 'adresseerbaar_object_id', default=None)
+        if pk is None:  # The link to adresseerbaar_object_id is missing, this should not happen but it does
+            detail_type = 'nummeraanduiding'
+            pk = _get_doc_attr(hit, 'landelijk_id', default=None)
     else:
         pk = _get_doc_attr(hit, 'landelijk_id', default=None)
     if pk is None:


### PR DESCRIPTION
…laats or standplaats is missing

return the the details for the nummeraanduiding itself. This should not happen, but it does and then we
do not want to be able to return the data that we have.

Example is : Marnixstraat 214