### PR TITLE
Limit the use of the v1.1 substring in URLs

### DIFF
--- a/bag/bag/urls.py
+++ b/bag/bag/urls.py
@@ -36,20 +36,20 @@ grouped_url_patterns = {
     ],
 
     'gebieden_patterns': [
-        url(r'^gebieden/v1.1/', include(bag.urlsets.gebieden.urls)),
+        url(r'^gebieden/', include(bag.urlsets.gebieden.urls)),
     ],
 
     'brk_patterns': [
-        url(r'^brk/v1.1/', include(bag.urlsets.brk.urls)),
+        url(r'^brk/', include(bag.urlsets.brk.urls)),
 
-        url(r'^brk/v1.1/object-wkpb/(?P<pk>[^/]+)/?$',
+        url(r'^brk/object-wkpb/(?P<pk>[^/]+)/?$',
             datasets.brk.views.KadastraalObjectWkpbView.as_view(
                 {'get': 'retrieve'}),
             name='brk-object-wkpb'),
     ],
 
     'beperkingen_patterns': [
-        url(r'^wkpb/v1.1/', include(bag.urlsets.wkpb.urls)),
+        url(r'^wkpb/', include(bag.urlsets.wkpb.urls)),
     ],
 }
 

--- a/bag/datasets/brk/tests/test_sensitive_details_jwt.py
+++ b/bag/datasets/brk/tests/test_sensitive_details_jwt.py
@@ -11,7 +11,7 @@ from . import factories
 
 class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
     
-    brk_root_url = '/brk/v1.1'
+    brk_root_url = '/brk'
 
     def setUp(self):
 
@@ -80,7 +80,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
             subj = response['kadastraal_subject']
             self.assertEqual(
                 subj['_links']['self']['href'],
-                'http://testserver/brk/v1.1/subject/{}/'.format(self.natuurlijk.pk)
+                'http://testserver/brk/subject/{}/'.format(self.natuurlijk.pk)
             )
 
     def test_uitgelogd_zakelijk_recht_niet_natuurlijk_hoofd_view(self):
@@ -148,7 +148,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
         self.client.credentials(
             HTTP_AUTHORIZATION='Bearer {}'.format(self.token_scope_brk_ro))
 
-        response = self.client.get(f'/brk/v1.1/object/{self.kot.pk}/')
+        response = self.client.get(f'/brk/object/{self.kot.pk}/')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("ACD00", str(response.data))
@@ -160,7 +160,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
             self.assertIn(field, data)
 
     def test_match_kot_object_public(self):
-        response = self.client.get(f'/brk/v1.1/object/{self.kot.pk}/')
+        response = self.client.get(f'/brk/object/{self.kot.pk}/')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("ACD00", str(response.data))
@@ -175,7 +175,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
         self.client.credentials(
             HTTP_AUTHORIZATION='Bearer {}'.format(self.token_scope_brk_ro))
 
-        response = self.client.get(f'/brk/v1.1/object-expand/{self.kot.pk}/')
+        response = self.client.get(f'/brk/object-expand/{self.kot.pk}/')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("ACD00", str(response.data))
@@ -187,7 +187,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
             self.assertIn(field, data)
 
     def test_match_kot_object__expandpublic(self):
-        response = self.client.get(f'/brk/v1.1/object-expand/{self.kot.pk}/')
+        response = self.client.get(f'/brk/object-expand/{self.kot.pk}/')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("ACD00", str(response.data))
@@ -202,7 +202,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
         self.client.credentials(
             HTTP_AUTHORIZATION='Bearer {}'.format(self.token_scope_wkpd_rdbu))
 
-        response = self.client.get(f'/brk/v1.1/object-wkpb/{self.kot.pk}/')
+        response = self.client.get(f'/brk/object-wkpb/{self.kot.pk}/')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("ACD00", str(response.data))
@@ -214,7 +214,7 @@ class SensitiveDetailsJwtTestCase(APITestCase, AuthorizationSetup):
             self.assertIn(field, data)
 
     def test_match_kot_object__wkpb_public(self):
-        response = self.client.get(f'/brk/v1.1/object-wkpb/{self.kot.pk}/')
+        response = self.client.get(f'/brk/object-wkpb/{self.kot.pk}/')
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("ACD00", str(response.data))

--- a/bag/datasets/tests/test_datasets.py
+++ b/bag/datasets/tests/test_datasets.py
@@ -39,26 +39,26 @@ class BrowseDatasetsTestCase(APITransactionTestCase, AuthorizationSetup):
         'bag/v1.1/openbareruimte',
         'bag/v1.1/woonplaats',
 
-        'gebieden/v1.1/stadsdeel',
-        'gebieden/v1.1/buurt',
-        'gebieden/v1.1/bouwblok',
-        'gebieden/v1.1/wijk',
-        'gebieden/v1.1/buurtcombinatie',
-        'gebieden/v1.1/gebiedsgerichtwerken',
-        'gebieden/v1.1/grootstedelijkgebied',
+        'gebieden/stadsdeel',
+        'gebieden/buurt',
+        'gebieden/bouwblok',
+        'gebieden/wijk',
+        'gebieden/buurtcombinatie',
+        'gebieden/gebiedsgerichtwerken',
+        'gebieden/grootstedelijkgebied',
 
-        'wkpb/v1.1/beperking',
-        'wkpb/v1.1/brondocument',
-        'wkpb/v1.1/broncode',
+        'wkpb/beperking',
+        'wkpb/brondocument',
+        'wkpb/broncode',
 
-        'brk/v1.1/gemeente',
-        'brk/v1.1/kadastrale-gemeente',
-        'brk/v1.1/kadastrale-sectie',
-        'brk/v1.1/object',
-        'brk/v1.1/object-expand',
-        'brk/v1.1/subject',
-        'brk/v1.1/zakelijk-recht',
-        'brk/v1.1/aantekening',
+        'brk/gemeente',
+        'brk/kadastrale-gemeente',
+        'brk/kadastrale-sectie',
+        'brk/object',
+        'brk/object-expand',
+        'brk/subject',
+        'brk/zakelijk-recht',
+        'brk/aantekening',
     ]
 
     formats = [
@@ -188,10 +188,10 @@ class BrowseDatasetsTestCase(APITransactionTestCase, AuthorizationSetup):
         urls = [
             # 'atlas/search',
             # 'atlas/typeahead',
-            'wkpb/v1.1',
+            'wkpb',
             'bag/v1.1',
-            'brk/v1.1',
-            'gebieden/v1.1',
+            'brk',
+            'gebieden',
         ]
 
         for url in urls:
@@ -357,7 +357,7 @@ class BrowseDatasetsTestCase(APITransactionTestCase, AuthorizationSetup):
 
     def test_brk_object_wkpb(self):
 
-        url = 'brk/v1.1/object'
+        url = 'brk/object'
 
         response = self.client.get('/{}/'.format(url))
 
@@ -371,7 +371,7 @@ class BrowseDatasetsTestCase(APITransactionTestCase, AuthorizationSetup):
 
     def test_brk_object_wkpb_html(self):
 
-        url = 'brk/v1.1/object'
+        url = 'brk/object'
 
         response = self.client.get(f'/{url}/', {'format': 'api'})
 
@@ -385,7 +385,7 @@ class BrowseDatasetsTestCase(APITransactionTestCase, AuthorizationSetup):
 
     def test_kos_filter(self):
 
-        url = 'brk/v1.1/subject'
+        url = 'brk/subject'
 
         response = self.client.get(f'/{url}/', {'buurt': self.buurt.vollcode})
 
@@ -393,7 +393,7 @@ class BrowseDatasetsTestCase(APITransactionTestCase, AuthorizationSetup):
 
     def test_aantekening_id(self):
 
-        url = 'brk/v1.1/aantekening'
+        url = 'brk/aantekening'
 
         aantekening_id = self.aantekening.aantekening_id
         _id = self.aantekening.id

--- a/bag/datasets/wkpb/tests/test_wkpb_sensitive_details.py
+++ b/bag/datasets/wkpb/tests/test_wkpb_sensitive_details.py
@@ -16,7 +16,7 @@ class ImportBeperkingVerblijfsobjectTaskTest(APITestCase, AuthorizationSetup):
 
     def test_match_brondocument_public(self):
         doc_id = self.brondocument.id
-        response = self.client.get(f'/wkpb/v1.1/brondocument/{doc_id}/')
+        response = self.client.get(f'/wkpb/brondocument/{doc_id}/')
 
         self.assertEqual(response.status_code, 200)
         data = str(response.data)
@@ -30,7 +30,7 @@ class ImportBeperkingVerblijfsobjectTaskTest(APITestCase, AuthorizationSetup):
             HTTP_AUTHORIZATION='Bearer {}'.format(self.token_scope_wkpd_rdbu))
 
         doc_id = self.brondocument.id
-        response = self.client.get(f'/wkpb/v1.1/brondocument/{doc_id}/')
+        response = self.client.get(f'/wkpb/brondocument/{doc_id}/')
 
         data = str(response.data)
 
@@ -42,7 +42,7 @@ class ImportBeperkingVerblijfsobjectTaskTest(APITestCase, AuthorizationSetup):
 
     def test_match_brondocument_public_list(self):
         doc_id = self.brondocument.id
-        response = self.client.get(f'/wkpb/v1.1/brondocument/')
+        response = self.client.get(f'/wkpb/brondocument/')
 
         self.assertEqual(response.status_code, 200)
 
@@ -59,7 +59,7 @@ class ImportBeperkingVerblijfsobjectTaskTest(APITestCase, AuthorizationSetup):
             HTTP_AUTHORIZATION='Bearer {}'.format(self.token_scope_wkpd_rdbu))
 
         doc_id = self.brondocument.id
-        response = self.client.get(f'/wkpb/v1.1/brondocument/')
+        response = self.client.get(f'/wkpb/brondocument/')
 
         data = response.data
 

--- a/bag/search/tests/test_redirects.py
+++ b/bag/search/tests/test_redirects.py
@@ -10,24 +10,24 @@ class CodeRedirectsTest(APITestCase):
 
     def testBouwblokCode(self):
         bbk = factories.BouwblokFactory.create(code='AN34')
-        res = self.client.get('/gebieden/v1.1/bouwblok/AN34/')
+        res = self.client.get('/gebieden/bouwblok/AN34/')
         bb_id = res.data['bouwblokidentificatie']
         self.assertEqual(bb_id, bbk.id)
 
     def testBouwblokCodeFilter(self):
         bbk = factories.BouwblokFactory.create(code='AN34')
-        res = self.client.get('/gebieden/v1.1/bouwblok/?code=AN34')
+        res = self.client.get('/gebieden/bouwblok/?code=AN34')
         bb_id = res.data['results'][0]['id']
         self.assertEqual(bb_id, bbk.id)
 
     def testStadsdeelCode(self):
         sdl = factories.StadsdeelFactory.create(code='X')
-        res = self.client.get('/gebieden/v1.1/stadsdeel/X/')
+        res = self.client.get('/gebieden/stadsdeel/X/')
         sd_id = res.data['stadsdeelidentificatie']
         self.assertEqual(sd_id, sdl.id)
 
     def testStadsdeelCodeFilter(self):
         sdl = factories.StadsdeelFactory.create(code='X')
-        res = self.client.get('/gebieden/v1.1/stadsdeel/?code=X')
+        res = self.client.get('/gebieden/stadsdeel/?code=X')
         sd = res.data['results'][0]
         self.assertEqual(sd['code'], sdl.code)


### PR DESCRIPTION
Only the BAG endpoints underwent a change big enought to warrant a new
version number. The other endpoints are more or less unchanged, only
source of the data is changed.