### PR TITLE
Propagate project name to running import

### DIFF
--- a/.jenkins-import/docker-compose.yml
+++ b/.jenkins-import/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     command: elasticsearch -Ehttp.host=0.0.0.0 -Etransport.host=127.0.0.1
 
   importer:
-    image: repo.data.amsterdam.nl/datapunt/bag_v11:${ENVIRONMENT}
+    image: repo.data.amsterdam.nl/datapunt/${PROJECT}:${ENVIRONMENT}
     container_name: "bag_v11${DC_IMPORT_NETWORK}_importer_1"
     networks:
       - network1

--- a/.jenkins-import/import.sh
+++ b/.jenkins-import/import.sh
@@ -7,7 +7,7 @@ set -x  # print all commands
 DIR="$(dirname $0)"
 
 dc() {
-	docker-compose -p bag_v11 -f ${DIR}/docker-compose.yml $*;
+	docker-compose -p bag_v11${DC_IMPORT_NETWORK} -f ${DIR}/docker-compose.yml $*;
 }
 
 trap 'dc kill ; dc rm -f' EXIT


### PR DESCRIPTION
Project name could be specified, the correct image would be checked out,
and subsequently the projectname used in docker-compose.yml would be run.
In effect would this change the project silently.

By propagating the project-name to the docker-compose.yml importing will
run within the same project.