### PR TITLE
DS-224 Fix problems with searching for "zijkanaal h 2" that is in the…

### DIFF
--- a/bag/datasets/bag/queries.py
+++ b/bag/datasets/bag/queries.py
@@ -140,6 +140,7 @@ def _basis_openbare_ruimte_query(
     if useorder:
         sort_fields = ['order', 'naam.keyword']
 
+    straat_naam = analyzer.get_straatnaam()
     return ElasticQueryWrapper(
         query={
             'bool': {
@@ -150,7 +151,7 @@ def _basis_openbare_ruimte_query(
                         'constant_score': {
                             'filter': {
                                 'prefix': {
-                                    'naam.keyword': analyzer.get_straatnaam(),
+                                    'naam.keyword': straat_naam,
                                 }
                             },
                             'boost': 10,
@@ -160,7 +161,7 @@ def _basis_openbare_ruimte_query(
                         'constant_score': {
                             'filter': {
                                 'multi_match': {
-                                    'query': analyzer.get_straatnaam(),
+                                    'query': straat_naam,
                                     'type': 'phrase_prefix',
                                     'fields': [
                                         'naam',

--- a/bag/search/analyzers.py
+++ b/bag/search/analyzers.py
@@ -41,13 +41,18 @@ huisnummer_expand = analysis.token_filter(
 )
 
 
-# Change dash and dot to space
-# https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pattern-replace-charfilter.html
+# Change dash and dot and slash to space
+# When this is done with pattern_replace this gives problems when searching for
+# zijkanaal h 2
+# It is also not needed to map quotes.
 naam_stripper = analysis.char_filter(
     'naam_stripper',
-    type="pattern_replace",
-    pattern=r"[-./']",  # replace these with spaces: "- . / '"
-    replace=" ",
+    type='mapping',
+    mappings=[
+        "-=>' '",  # change '-' to separator
+        ".=>' '",  # change '.' to separator
+        "/=>' '",  # change '/' to separator
+    ]
 )
 
 # normalizes ., -, / to space from text


### PR DESCRIPTION
… search tests

If dashes are replaced with pattern_replace that is interpreted differently for Zijkanaal H-weg 2
So this should be done instead with the mapping type char_filter

The quote character should also not be included in ther mapping replace. We can search
directly for the  quotei character in ES.

This will also fix DS-226 about UTF-8 Apostrophe because the asciifolding will take replace any
UTF characters by their ascii counterparts.