### PR TITLE
DI-495 - Make typeahead search for nummeraanduiding better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ username, assumes your public SSH key is known and you have appropriate level of
 This command expects the private SSH key to be found in the ~/.ssh T†folder,
 in a file with the name datapunt.key (chmod 600):
 
-    docker-compose exec database update-db.sh bag_v11 <username>
+    docker-compose exec database update-db.sh bag_v11
 
 To import the latest elastic index from acceptance:
 

--- a/bag/datasets/bag/queries.py
+++ b/bag/datasets/bag/queries.py
@@ -270,8 +270,9 @@ def straatnaam_huisnummer_query(analyzer: QueryAnalyzer) -> Search:
                 ],
             },
         },
-        sort_fields=['straatnaam.raw', 'huisnummer', 'toevoeging.keyword'],
-        indexes=[NUMMERAANDUIDING]
+        sort_fields=['_score', 'straatnaam.raw', 'huisnummer', 'toevoeging.keyword'],
+        indexes=[NUMMERAANDUIDING],
+        search_type="dfs_query_then_fetch"
     )
 
 

--- a/bag/search/queries.py
+++ b/bag/search/queries.py
@@ -11,13 +11,16 @@ def create_search_query(
         query: dict,
         indexes: List[str],
         sort_fields: List[str] = None,
-        size: int = 15
+        size: int = 15,
+        search_type = None,
 ) -> Search:
     """
     :param query: an elastic search query
     :param indexes: list of indexes to use
     :param sort_fields: an optional list of fields to use for server-side sorting
     :param size: an optional limit on size of the result set
+    :param search_type: search_type to be passed. For example dfs_query_then_fetch. See :
+      https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-body.html#dfs-query-then-fetch
     """
     assert indexes
 
@@ -26,6 +29,8 @@ def create_search_query(
         .index(*indexes)
         .query(query)
     )
+    if search_type:
+        search = search.params(search_type=search_type)
     if sort_fields:
         search = search.sort(*sort_fields)
 


### PR DESCRIPTION
First use the score for sorting the results, then the streetname and number.
In order to get consistent scoring we shoud do the search with :

search_type=dfs_query_then_fetch

See : https://www.elastic.co/guide/en/elasticsearch/reference/master/consistent-scoring.html