### PR TITLE
Bump Django to 2.2.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cryptography==3.3.2
 datapunt-authorization-django==1.3.2
 debtcollector==1.20.0
 defusedxml==0.6.0
-Django==2.2.27
+Django==2.2.28
 django-debug-toolbar==1.11.1
 django-elasticsearch-debug-toolbar==2.0.0
 django-extensions==2.1.4


### PR DESCRIPTION
Bump Django because of CVE-2022-28346.
https://docs.djangoproject.com/en/4.0/releases/2.2.28/