### PR TITLE
Always include Weesp in search results.

### DIFF
--- a/bag/search/views.py
+++ b/bag/search/views.py
@@ -527,13 +527,12 @@ class TypeaheadViewSet(viewsets.ViewSet):
               paramType: query
         """
         query = request.query_params.get('q')
-        if 'features' in request.query_params:
-            features = request.query_params['features']
-            self.features = int(features) if features.isdigit() else 0
-        else:
-            referer = request.headers.get('Referer')
-            if referer and referer.endswith('data.amsterdam.nl/'):
-                self.features = settings.ENABLE_WEESP_TYPEAHEAD
+	# Always search for objects in Weesp.
+	# Previously, this flag was depending on a request 
+	# parameters `features` with a value of 2,
+	# however, the Weesp/Amsterdam merger is now final,
+	# so searches should always include Weesp.
+        self.features = settings.ENABLE_WEESP_TYPEAHEAD
 
         if not query:
             return Response([])


### PR DESCRIPTION
Previously, including Weesp was depending on the `features=2`
request parameter. However, Weesp now just needs to be always included.

This has only been changed by disabling the feature flag.
The handling in the construction of the elasticsearch queries
is not touched, because this is quite complex.
Better not introduce new bugs :-)

This could be done when search is being migrated to Azure.