### PR TITLE
Disable Kadastrale subjecten view

### DIFF
--- a/bag/search/tests/test_subject.py
+++ b/bag/search/tests/test_subject.py
@@ -51,14 +51,14 @@ class SubjectSearchTest(APITestCase, AuthorizationSetup):
         response = self.client.get(
             '/atlas/search/kadastraalsubject/',
             {'q': 'Stephan Preeker'})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("Stephan Jacob Preeker", str(response.data))
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("Stephan Jacob Preeker", str(response.data))
 
         response = self.client.get(
             '/atlas/search/kadastraalsubject/',
             {'q': 'stoeptegel'})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("stoeptegel", str(response.data))
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("stoeptegel", str(response.data))
 
     def test_match_subject2_not_authorizer(self):
         self.client.credentials(
@@ -85,15 +85,15 @@ class SubjectSearchTest(APITestCase, AuthorizationSetup):
             '/atlas/search/kadastraalsubject/',
             {'q': 'Stephan Preeker'})
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
         self.assertNotIn("Stephan Jacob Preeker", str(response.data))
 
-        # we should find stoeptegel
+        # we should NOT find stoeptegel
         response = self.client.get(
             '/atlas/search/kadastraalsubject/',
             {'q': 'stoeptegel'})
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("stoeptegel", str(response.data))
+        self.assertEqual(response.status_code, 403)
+        self.assertNotIn("stoeptegel", str(response.data))
 
     def test_match_subject_not_authorized(self):
         self.client.credentials(
@@ -130,7 +130,7 @@ class SubjectSearchTest(APITestCase, AuthorizationSetup):
             '/atlas/typeahead/brk/',
             {'q': 'Stephan Preeker'})
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Stephan Jacob Preeker", str(response.data))
+        self.assertNotIn("Stephan Jacob Preeker", str(response.data))
 
         response = self.client.get(
             '/atlas/typeahead/brk/',
@@ -138,7 +138,7 @@ class SubjectSearchTest(APITestCase, AuthorizationSetup):
 
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn("stoeptegel", str(response.data))
+        self.assertNotIn("stoeptegel", str(response.data))
 
     def test_match_typeahead_subject_not_authorized(self):
         self.client.credentials(
@@ -167,9 +167,9 @@ class SubjectSearchTest(APITestCase, AuthorizationSetup):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Stephan Jacob Preeker", str(response.data))
 
-        # but other subjects yes.
+        # also no other subjects.
         response = self.client.get(
             '/atlas/typeahead/brk/', {'q': 'stoeptegel'})
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn("stoeptegel", str(response.data))
+        self.assertNotIn("stoeptegel", str(response.data))

--- a/bag/search/views.py
+++ b/bag/search/views.py
@@ -528,7 +528,7 @@ class TypeaheadViewSet(viewsets.ViewSet):
         """
         query = request.query_params.get('q')
 	# Always search for objects in Weesp.
-	# Previously, this flag was depending on a request 
+	# Previously, this flag was depending on a request
 	# parameters `features` with a value of 2,
 	# however, the Weesp/Amsterdam merger is now final,
 	# so searches should always include Weesp.
@@ -559,27 +559,16 @@ class TypeAheadBagViewSet(TypeaheadViewSet):
 
 def authorized_subject_queries(request, analyzer) -> List[Search]:
     """
-    Decide if which query we can execute
+    Execute subject queries.
 
-    public - no subjects
-    employ - non natural subjects / nietnatuurlijk
-    plus   - all subjects
+    Never return anything from this function, regardless of what
+    the authorization is. Freely searching in personal data
+    (like kadastraal subject) should not be possible at all.
+
+    This functions was returning results for some authorization
+    scope. However, free search should not be possible at all.
     """
 
-    authorized = request.is_authorized_for(authorization_levels.SCOPE_BRK_RSN)
-
-    # Scope BRK/RSN or EMPLOYEE PLUS
-    if authorized:
-        return [brk_qs.kadastraal_subject_query(analyzer)]
-
-    # Scope BRK/RS or EMPLOYEE
-    niet_natuurlijk = brk_qs.kadastraal_subject_nietnatuurlijk_query
-    authorized = request.is_authorized_for(authorization_levels.SCOPE_BRK_RS)
-
-    if authorized:
-        return [niet_natuurlijk(analyzer)]
-
-    # NOT AUTHORIZED / PUBLIC
     return []
 
 


### PR DESCRIPTION
It should not be possible to do free (wildcards) searches in this content. Is it personal data.

Tests have been changed accordingly.