### PR TITLE
Bump `djangorestframework` to update jQuery to 3.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,10 @@ django-extensions==2.1.4
 django-filter==2.4.0
 django-rest-swagger==2.2.0
 django-shotgun==0.2
-djangorestframework==3.11.2
+djangorestframework==3.12.4
 djangorestframework-csv==2.1.0
-djangorestframework-gis==0.14
-djangorestframework-xml==1.4.0
+djangorestframework-gis==1.0.0
+djangorestframework-xml==2.0.0
 docker==4.4.1
 docker-compose==1.27.4
 docker-pycreds==0.4.0


### PR DESCRIPTION
https://nvd.nist.gov/products/cpe/detail/23B812B9-5F5A-4FB9-AB74-FA0B1DA2BB5E
https://www.django-rest-framework.org/community/release-notes/#312x-series

3.4.1 is vulnarable