### PR TITLE
POC loading ref db data into bag_v11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 htmlcov/
 .coverage
 .envrc
+docker-compose.override.*
 
 # Other..?
 .DS_Store

--- a/bag/bag/settings/settings.py
+++ b/bag/bag/settings/settings.py
@@ -69,6 +69,13 @@ DATABASES = {
     'default': DATABASE_OPTIONS[get_database_key()]
 }
 
+DATABASE_SCHEMA =  os.getenv("DATABASE_SCHEMA")
+if DATABASE_SCHEMA is not None:
+    # https://www.postgresql.org/docs/11/ddl-schemas.html under 5.8.3
+    # public is required for using the PostGis extension
+    # TODO: move Postgis objects to a separate schema
+    DATABASES["default"]["OPTIONS"] = {"options": f"-c search_path={DATABASE_SCHEMA},public"}
+
 if os.getenv("AZURE", False):
     DATABASES["default"]["PASSWORD"] = Path(os.environ["DATABASE_PW_LOCATION"]).open().read()
 

--- a/bag/datasets/bag/models.py
+++ b/bag/datasets/bag/models.py
@@ -38,6 +38,7 @@ class Gemeente(mixins.GeldigheidMixin, models.Model):
 
     date_modified = models.DateTimeField(auto_now=True)
     naam = models.CharField(max_length=40)
+
     verzorgingsgebied = models.NullBooleanField(default=None)
     vervallen = models.NullBooleanField(default=None)
 
@@ -49,13 +50,7 @@ class Gemeente(mixins.GeldigheidMixin, models.Model):
         return self.naam
 
 
-class Hoofdklasse(models.Model):
-    """
-    De hoofdklasse is een abstracte klasse waar sommige andere
-    gebiedsklassen, zoals stadsdeel en buurt, van afstammen.
-    Deze afstammelingen erven alle kenmerken over van deze hoofdklasse.
-    """
-
+class GeometryMixin(models.Model):
     geometrie = geo.MultiPolygonField(null=True, srid=28992)
     date_modified = models.DateTimeField(auto_now=True)
 
@@ -65,7 +60,7 @@ class Hoofdklasse(models.Model):
         abstract = True
 
 
-class Woonplaats(mixins.GeldigheidMixin, mixins.DocumentStatusMixin, Hoofdklasse):
+class Woonplaats(mixins.GeldigheidMixin, mixins.DocumentStatusMixin, GeometryMixin):
 
     id = models.CharField(max_length=14, primary_key=True)
 
@@ -83,7 +78,7 @@ class Woonplaats(mixins.GeldigheidMixin, mixins.DocumentStatusMixin, Hoofdklasse
         return self.naam
 
 
-class Stadsdeel(mixins.GeldigheidMixin, Hoofdklasse):
+class Stadsdeel(mixins.GeldigheidMixin, GeometryMixin):
     """
     Door de Amsterdamse gemeenteraad vastgestelde begrenzing van
     een stadsdeel, ressorterend onder een stadsdeelbestuur.
@@ -108,7 +103,7 @@ class Stadsdeel(mixins.GeldigheidMixin, Hoofdklasse):
         return f"{self.naam} ({self.code})"
 
 
-class Buurt(mixins.GeldigheidMixin, Hoofdklasse):
+class Buurt(mixins.GeldigheidMixin, GeometryMixin):
     """
     Een aaneengesloten gedeelte van een buurt, waarvan de grenzen
     zo veel mogelijk gebaseerd zijn op topografische elementen.
@@ -147,7 +142,7 @@ class Buurt(mixins.GeldigheidMixin, Hoofdklasse):
         return self.stadsdeel.gemeente
 
 
-class Bouwblok(mixins.GeldigheidMixin, Hoofdklasse):
+class Bouwblok(mixins.GeldigheidMixin, GeometryMixin):
     """
     Een bouwblok is het kleinst mogelijk afgrensbare gebied, in
     zijn geheel tot een buurt behorend, dat geheel of
@@ -186,7 +181,7 @@ class Bouwblok(mixins.GeldigheidMixin, Hoofdklasse):
         return self._stadsdeel.gemeente if self._stadsdeel else None
 
 
-class OpenbareRuimte(mixins.GeldigheidMixin, mixins.DocumentStatusMixin, Hoofdklasse):
+class OpenbareRuimte(mixins.GeldigheidMixin, mixins.DocumentStatusMixin, GeometryMixin):
     """
     Een OPENBARE RUIMTE is een door het bevoegde gemeentelijke orgaan als
     zodanig aangewezen en van een naam voorziene
@@ -259,7 +254,7 @@ class OpenbareRuimte(mixins.GeldigheidMixin, mixins.DocumentStatusMixin, Hoofdkl
         return dct
 
 
-class Gebiedsgerichtwerken(Hoofdklasse):
+class Gebiedsgerichtwerken(GeometryMixin):
     """
     model for data from shp files
 
@@ -287,7 +282,7 @@ class Gebiedsgerichtwerken(Hoofdklasse):
         return "{} ({})".format(self.naam, self.code)
 
 
-class GebiedsgerichtwerkenPraktijkgebieden(Hoofdklasse):
+class GebiedsgerichtwerkenPraktijkgebieden(GeometryMixin):
     """
     model for data from shp files
 
@@ -307,7 +302,7 @@ class GebiedsgerichtwerkenPraktijkgebieden(Hoofdklasse):
         return "{}".format(self.naam)
 
 
-class Grootstedelijkgebied(Hoofdklasse):
+class Grootstedelijkgebied(GeometryMixin):
     """
     model for data from shp files
 

--- a/bag/datasets/bag/views.py
+++ b/bag/datasets/bag/views.py
@@ -76,6 +76,7 @@ class LigplaatsViewSet(rest.DatapuntViewSet):
 
     [Stelselpedia](http://www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-1/)
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Ligplaats.objects.all().order_by('id')
@@ -113,6 +114,7 @@ class StandplaatsViewSet(rest.DatapuntViewSet):
 
     [Stelselpedia](http://www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-4/)
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Standplaats.objects.all()
@@ -187,6 +189,7 @@ class VerblijfsobjectViewSet(rest.DatapuntViewSet):
 
     [Stelselpedia](http://www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-0/)
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Verblijfsobject.objects
@@ -354,6 +357,7 @@ class NummeraanduidingViewSet(rest.DatapuntViewSet):
     TIP! detailed=1 if you want all fields in the list view!
 
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = (
@@ -474,6 +478,7 @@ class PandViewSet(rest.DatapuntViewSet):
 
     TIP! detailed=1 if you want all fields in the list view!
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
 
@@ -573,6 +578,7 @@ class OpenbareRuimteViewSet(rest.DatapuntViewSet):
     [Stelselpedia]
     (http://www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse-3/)
     """  # noqa
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.OpenbareRuimte.objects.distinct()
@@ -603,6 +609,7 @@ class WoonplaatsViewSet(rest.DatapuntViewSet):
 
     [Stelselpedia](https://www.amsterdam.nl/stelselpedia/bag-index/catalogus-bag/objectklasse/)   # noqa
     """  # noqa
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Woonplaats.objects.all().order_by('id')
@@ -634,6 +641,7 @@ class StadsdeelViewSet(rest.DatapuntViewSet):
     [Stelselpedia]
     (https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/stadsdeel/)
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Stadsdeel.objects.all().order_by('id')
@@ -666,6 +674,7 @@ class BuurtViewSet(rest.DatapuntViewSet):
     [Stelselpedia]
     (https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt/)
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Buurt.objects.all().order_by('naam')
@@ -694,6 +703,7 @@ class BouwblokViewSet(rest.DatapuntViewSet):
     [Stelselpedia]
     (https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/bouwblok/)
     """
+    # queries PG
 
     metadata_class = ExpansionMetadata
     queryset = models.Bouwblok.objects.all()
@@ -738,6 +748,7 @@ class BuurtcombinatieViewSet(rest.DatapuntViewSet):
     filterset_fields = (
         'stadsdeel', 'vollcode', 'code', 'naam', 'stadsdeel',
         'buurten')
+    # queries PG
 
 
 class GebiedsgerichtwerkenViewSet(rest.DatapuntViewSet):
@@ -759,6 +770,7 @@ class GebiedsgerichtwerkenViewSet(rest.DatapuntViewSet):
     serializer_class = serializers.Gebiedsgerichtwerken
 
     filterset_fields = ('stadsdeel__id', 'stadsdeel')
+    # queries PG
 
 
 class GebiedsgerichtwerkenPraktijkgebiedenViewSet(rest.DatapuntViewSet):
@@ -778,6 +790,7 @@ class GebiedsgerichtwerkenPraktijkgebiedenViewSet(rest.DatapuntViewSet):
     queryset = models.GebiedsgerichtwerkenPraktijkgebieden.objects.all().order_by('naam')
     serializer_detail_class = serializers.GebiedsgerichtwerkenPraktijkgebiedenDetail
     serializer_class = serializers.GebiedsgerichtwerkenPraktijkgebieden
+    # queries PG
 
 
 class GrootstedelijkgebiedViewSet(rest.DatapuntViewSet):
@@ -795,6 +808,7 @@ class GrootstedelijkgebiedViewSet(rest.DatapuntViewSet):
     queryset = models.Grootstedelijkgebied.objects.all().order_by('naam')
     serializer_detail_class = serializers.GrootstedelijkgebiedDetail
     serializer_class = serializers.Grootstedelijkgebied
+    # queries PG
 
 
 class UnescoViewSet(rest.DatapuntViewSet):
@@ -814,25 +828,4 @@ class UnescoViewSet(rest.DatapuntViewSet):
     queryset = models.Unesco.objects.all()
     serializer_detail_class = serializers.UnescoDetail
     serializer_class = serializers.Unesco
-
-
-class BouwblokCodeView(RedirectView):
-    """
-    Bouwblokcode
-    """
-
-    permanent = False
-
-    def get_redirect_url(self, *args, **kwargs):
-        bouwblok = get_object_or_404(
-            models.Bouwblok, code__iexact=kwargs['code'])
-        return reverse('bouwblok-detail', kwargs=dict(pk=bouwblok.pk))
-
-
-class StadsdeelCodeView(RedirectView):
-    permanent = False
-
-    def get_redirect_url(self, *args, **kwargs):
-        stadsdeel = get_object_or_404(
-            models.Stadsdeel, code__iexact=kwargs['code'])
-        return reverse('stadsdeel-detail', kwargs=dict(pk=stadsdeel.pk))
+    # queries PG

--- a/bag/datasets/brk/models.py
+++ b/bag/datasets/brk/models.py
@@ -8,6 +8,7 @@ from datasets.generic import kadaster
 
 
 class Gemeente(models.Model):
+    # ams-schema: brk.gemeentes
     gemeente = models.CharField(max_length=50, primary_key=True)
 
     geometrie = geo.MultiPolygonField(srid=28992)
@@ -25,6 +26,7 @@ class Gemeente(models.Model):
 
 
 class KadastraleGemeente(models.Model):
+    # ams-schema: brk.kadastralegemeentes
     id = models.CharField(max_length=200, primary_key=True)
     naam = models.CharField(max_length=100)
     gemeente = models.ForeignKey(
@@ -47,6 +49,7 @@ class KadastraleGemeente(models.Model):
 
 
 class KadastraleSectie(models.Model):
+    # ams-schema: brk.kadastraleselecties
     id = models.CharField(max_length=200, primary_key=True)
 
     sectie = models.CharField(max_length=2)
@@ -72,6 +75,7 @@ class KadastraleSectie(models.Model):
 
 
 class KadasterCodeOmschrijving(models.Model):
+    # ams-schema: ?
     code = models.CharField(max_length=50, primary_key=True)
     omschrijving = models.TextField()
 
@@ -131,6 +135,7 @@ class KadastraalSubject(models.Model):
 
     https://www.amsterdam.nl/stelselpedia/brk-index/catalog-brk-levering/kadastraal-subject/
     """
+    # ams-schema: brk.kadastralesubjecten
     SUBJECT_TYPE_NATUURLIJK = 0
     SUBJECT_TYPE_NIET_NATUURLIJK = 1
     SUBJECT_TYPE_CHOICES = (
@@ -243,6 +248,7 @@ class APerceelGPerceelRelatie(models.Model):
 
 
 class KadastraalObject(models.Model):
+    # ams-schema: brk.kadastraleobjecten
     id = models.CharField(max_length=60, primary_key=True)
     aanduiding = models.CharField(max_length=17)
 
@@ -327,6 +333,7 @@ class KadastraalObjectVerblijfsobjectRelatie(models.Model):
 
 
 class AardZakelijkRecht(KadasterCodeOmschrijving):
+    # ams-schema: brk.aardzakelijkerechten
     """
     2	Eigendom (recht van)
     3	Erfpacht (recht van)
@@ -349,6 +356,7 @@ class AppartementsrechtsSplitsType(KadasterCodeOmschrijving):
 
 
 class ZakelijkRecht(models.Model):
+    # ams-schema: brk.zakelijkerechten
     id = models.CharField(max_length=183, primary_key=True)
 
     date_modified = models.DateTimeField(auto_now=True)
@@ -435,6 +443,7 @@ class AardAantekening(KadasterCodeOmschrijving):
 
 
 class Aantekening(models.Model):
+    # ams-schema: brk.aantekeningenrechten?
 
     aantekening_id = models.CharField(max_length=60, db_index=True)
     aard_aantekening = models.ForeignKey(

--- a/bag/datasets/brk/views.py
+++ b/bag/datasets/brk/views.py
@@ -45,6 +45,7 @@ class GemeenteViewSet(DatapuntViewSet):
     serializer_class = serializers.Gemeente
     serializer_detail_class = serializers.GemeenteDetail
     lookup_value_regex = '[^/]+'
+    # queries PG
 
 
 class KadastraleGemeenteViewSet(DatapuntViewSet):
@@ -62,6 +63,7 @@ class KadastraleGemeenteViewSet(DatapuntViewSet):
     serializer_class = serializers.KadastraleGemeente
     serializer_detail_class = serializers.KadastraleGemeenteDetail
     lookup_value_regex = '[^/]+'
+    # queries PG
 
 
 class KadastraleSectieViewSet(DatapuntViewSet):
@@ -81,6 +83,7 @@ class KadastraleSectieViewSet(DatapuntViewSet):
     serializer_class = serializers.KadastraleSectie
     serializer_detail_class = serializers.KadastraleSectieDetail
     filterset_fields = ('kadastrale_gemeente',)
+    # queries PG
 
 
 class SubjectFilter(FilterSet):
@@ -174,6 +177,7 @@ class KadastraalSubjectViewSet(DatapuntViewSet):
     lookup_value_regex = '[^/]+'
 
     filterset_class = SubjectFilter
+    # queries PG
 
     # NOTE in serializer there is MORE authorization code!!
 
@@ -347,6 +351,7 @@ class KadastraalObjectViewSet(DatapuntViewSet):
             'voornaamste_gerechtigde',
         )
     )
+    # queries PG
 
     filterset_class = KadastraalObjectFilter
 
@@ -477,6 +482,7 @@ class ZakelijkRechtViewSet(DatapuntViewSet):
     serializer_detail_class = serializers.ZakelijkRechtDetail
 
     filterset_class = ZakelijkRechtFilter
+    # queries PG
 
     lookup_value_regex = '[^/]+'
 
@@ -566,6 +572,7 @@ class AantekeningViewSet(DatapuntViewSet):
             'kadastraal_object', 'kadastraal_object__sectie',
             'kadastraal_object__kadastrale_gemeente')
     )
+    # queries PG
 
     serializer_class = serializers.Aantekening
     serializer_detail_class = serializers.AantekeningDetail

--- a/bag/search/views.py
+++ b/bag/search/views.py
@@ -1,7 +1,8 @@
 """
 Typeahead bag, brk
-
 Search    bag, brk
+
+Views that are querying Elasticsearch
 """
 from __future__ import annotations
 
@@ -38,8 +39,8 @@ from search.query_analyzer import QueryAnalyzer
 log = logging.getLogger(__name__)
 
 CallableQueryFunction = Callable[[QueryAnalyzer], Search]
-
 # Mapping of subtypes with detail views
+
 _details = {
     'ligplaats': 'ligplaats-detail',
     'standplaats': 'standplaats-detail',
@@ -631,16 +632,6 @@ class TypeAheadGebiedenViewSet(TypeaheadViewSet):
 
     def list(self, request):
         return self._abstr_list(request, {'gebieden'})
-
-
-class TypeAheadLegacyViewSet(TypeaheadViewSet):
-    """
-    The old typeahead containing all different results at once
-    """
-
-    def list(self, request):
-        return self._abstr_list(request, set())
-
 
 class SearchViewSet(viewsets.ViewSet):
     """

--- a/bag_refdb.sql
+++ b/bag_refdb.sql
@@ -1,0 +1,83 @@
+/*
+    Load data from the reference database into the bag_v11 structure.
+
+    This is a mechanism that makes legacy systems consume from data in
+    the reference database in order to remove the dependency on legacy
+    databases while keeping these systems alive until clients have
+    migrated to the DSO-API.
+    
+    | REF DB                     |  BAG V11                   |
+    | brk_gemeentes              |  brk_gemeente              |
+    | brk_kadastralegemeentes    |  brk_kadastralegemeente    |
+
+    Note that dimensions and primary keys between "corresponding" 
+    tables are not always the same, so we need to make a case-by-case
+    decision on how to map ref-db entries to the bag_v11 entries.
+    These decisions are clarified below:
+
+    Column specific mappings:
+    
+    * Ref-db brk_gemeentes has a temporal dimension which does not exist in bagv11:
+      To remove this, we take the most recent version of the gemeente.
+      Any relations pointing older versions will implicitly be dropped in the mapped data.
+    * bag_v11 brk_gemeente uses naam as primary key while ref-db brk_gemeentes uses
+      a temporal composite key:
+      This is also solved by taking the most recent version of the gemeente
+    * bag_v11 brk_kadastralegemeente uses a KADGEMCODE (from GOB objectstore):
+      This code is not present in ref-db so it is dropped.
+      
+    General mappings:
+
+    * spatial columns with mixed geometries are cast to their ST_Multi equivalent
+
+*/
+
+INSERT INTO
+    bag_services.brk_gemeente (gemeente, geometrie, date_modified) (
+        SELECT
+            attr.naam as gemeente,
+            ST_Multi(attr.geometrie) as geometrie,
+            now() as date_modified
+        FROM
+            (
+                SELECT
+                    identificatie,
+                    MAX(volgnummer) AS mxvolgnummer
+                FROM public.brk_gemeentes
+                GROUP BY
+                    identificatie
+            ) AS unik
+            INNER JOIN public.brk_gemeentes attr ON attr.identificatie = unik.identificatie
+            AND unik.mxvolgnummer = attr.volgnummer
+    );
+
+INSERT INTO
+    bag_services.brk_kadastralegemeente (
+        id,
+        naam,
+        gemeente_id,
+        geometrie,
+        geometrie_lines,
+        date_modified
+    ) (
+        SELECT
+            kg.identificatie AS id,
+            kg.identificatie AS naam,
+            gm.naam AS gemeente_id,
+            ST_Multi(kg.geometrie) AS geometrie,
+            ST_Multi(ST_Boundary(kg.geometrie)) :: geometry(MULTILINESTRING, 28992) AS geometrie_lines,
+            now() AS date_modified
+        FROM
+            (
+                SELECT
+                    identificatie,
+                    MAX(volgnummer) max_volgnummer
+                FROM
+                    public.brk_gemeentes
+                GROUP BY
+                    identificatie
+            ) AS g
+            INNER JOIN public.brk_kadastralegemeentes kg ON g.identificatie = kg.ligt_in_gemeente_identificatie
+            INNER JOIN public.brk_gemeentes gm ON g.identificatie = gm.identificatie
+            AND g.max_volgnummer = gm.volgnummer
+    );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "8080:8080"
     links:
-      - database
+      #- database
       - elasticsearch
     environment:
       - DATAPUNT_API_URL=${DATAPUNT_API_URL:-https://api.data.amsterdam.nl/}

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ factory-boy==2.11.1
 Faker==1.0.1
 first==2.0.1
 frosted==1.4.1
-futures==3.1.1
 graypy==0.3.1
 httplib2==0.19.0
 idna==2.8
@@ -70,7 +69,7 @@ packaging==21.3
 pbr==5.1.1
 pies==2.6.7
 positional==1.2.1
-psycopg2-binary==2.7.6.1
+psycopg2-binary==2.8.6
 pycodestyle==2.4.0
 pycparser==2.19
 pyflakes==2.0.0
@@ -92,7 +91,6 @@ sqlparse==0.2.4
 stevedore==1.30.0
 text-unidecode==1.2
 texttable==1.5.0
-typed-ast==1.2.0
 typing==3.6.6
 unicodecsv==0.14.1
 uritemplate==3.0.0


### PR DESCRIPTION
Used brk gemeentes and kadastralegemeentes to explore the feasibility of mapping data from the refdb to bag_v11, so far so good. Tested the application running on a different schema serving data loaded from the ref-db.

Ideally, this should not be necessary but it currently seems the only way to move away from the legacy databases without having to wait on clients to move to DSO-API.

* Add support for interacting with a custom postgres schema
* Some small cleanups and annotations in comments in preparation for making this work with the ref db
* Removed typed-ast and futures (not used) upgraded postgres adapter