### PR TITLE
Move the checkout and build step to the same node block as build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,24 +18,22 @@ def tryStep(String message, Closure block, Closure tearDown = null) {
     }
 }
 
-
-node {
-    stage("Checkout") {
-        checkout scm
-    }
-
-    stage('Test') {
-        tryStep "test", {
-            sh ".jenkins-test/test.sh"
-        }
-    }
-}
-
 String BRANCH = "${env.BRANCH_NAME}"
 
 if (BRANCH == "gob_only_imports") {
 
     node {
+
+        stage("Checkout") {
+            checkout scm
+        }
+
+        stage('Test') {
+            tryStep "test", {
+                sh ".jenkins-test/test.sh"
+            }
+        }
+
         stage("Build image") {
             tryStep "build", {
                 docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
@@ -77,11 +75,23 @@ if (BRANCH == "gob_only_imports") {
 
 if (BRANCH == "master") {
 
-    stage("Build image") {
-        tryStep "build", {
-                docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
-                def image = docker.build("datapunt/bag_v11:${env.BUILD_NUMBER}")
-                image.push()
+    node {
+        stage("Checkout") {
+            checkout scm
+        }
+
+        stage('Test') {
+            tryStep "test", {
+                sh ".jenkins-test/test.sh"
+            }
+        }
+
+        stage("Build image") {
+            tryStep "build", {
+                    docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
+                    def image = docker.build("datapunt/bag_v11:${env.BUILD_NUMBER}")
+                    image.push()
+                }
             }
         }
     }


### PR DESCRIPTION
Jenkins recently got additional build machines.
Now the image build end up on another manchine that does not have the checkout of the code. So, checkout has now been moved inside the same block as the build step.