### PR TITLE
IMDS token script

### DIFF
--- a/bag/get_imds_db_token.sh
+++ b/bag/get_imds_db_token.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# This script echoes a shortlived token for connecting to a postgres instance
+# It can only be used from a K8S node with the proper identities assigned.
+
+
+url='http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fossrdbms-aad.database.windows.net'
+curl -s "$url" -H 'Metadata: true' |
+    python -c 'import json, sys; print(json.loads(sys.stdin.read())["access_token"])'


### PR DESCRIPTION
script to get shortlived tokens from Azure MetadataService based on the underlying VM managed identity so we can perform ETL tasks that need write access to the db