### PR TITLE
Add api key server middleware + config

### DIFF
--- a/bag/bag/settings/settings.py
+++ b/bag/bag/settings/settings.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -269,3 +270,12 @@ if SENTRY_DSN:
 # Define feature values for runtime dependent behaviour in parameters
 # 1 was already user earlier and might still be in use by dataportaal
 ENABLE_WEESP_TYPEAHEAD = 2
+
+APIKEY_MANDATORY = False
+APIKEY_ENDPOINT = os.getenv("APIKEY_ENDPOINT", "http://localhost:8001/signingkeys/")
+apikey_localkeys_env = os.getenv("APIKEY_LOCALKEYS", None)
+if apikey_localkeys_env is None:
+    APIKEY_LOCALKEYS = None
+else:
+    APIKEY_LOCALKEYS = json.loads(apikey_localkeys_env)
+

--- a/bag/bag/settings/settings_common.py
+++ b/bag/bag/settings/settings_common.py
@@ -59,6 +59,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'authorization_django.authorization_middleware',
+    'apikeyclient.ApiKeyMiddleware',
 ]
 
 if DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.2
 cryptography==41.0.4
+datadiensten-apikeysclient==0.3.5
 datapunt-authorization-django==1.3.2
 debtcollector==1.20.0
 defusedxml==0.6.0
@@ -27,7 +28,6 @@ djangorestframework-csv==2.1.0
 djangorestframework-gis==1.0.0
 djangorestframework-xml==2.0.0
 docker==4.4.1
-docker-compose==1.27.4
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2
@@ -80,7 +80,7 @@ python-dateutil==2.7.5
 python-keystoneclient==3.18.0
 python-swiftclient==3.6.0
 pytz==2018.9
-PyYAML==5.4
+PyYAML==6.0.1
 requests==2.31.0
 rfc3986==1.2.0
 sentry-sdk==1.14.0


### PR DESCRIPTION
The APIs in this repo will get an API Key check.
Initially the API Key is not mandatory.

The API key check is done by a Django middleware (datadiensten-apikeysclient) and the configuration that is needed is added to the Django settings.

The public signing keys will be added to the container during deployment from the Openstack ansible playbook.