### PR TITLE
Fix adres query for missing straatnaam raw

### DIFF
--- a/bag/datasets/bag/queries.py
+++ b/bag/datasets/bag/queries.py
@@ -48,7 +48,7 @@ def postcode_huisnummer_query(analyzer: QueryAnalyzer, features: int = 0) -> Sea
             },
         },
         indexes=[NUMMERAANDUIDING],
-        sort_fields=['straatnaam.raw', 'huisnummer', 'toevoeging.keyword']
+        sort_fields=[{'straatnaam.raw': {'unmapped_type': 'long'}}, 'huisnummer', 'toevoeging.keyword']
     )
 
 
@@ -67,7 +67,7 @@ def postcode_huisnummer_exact_query(analyzer: QueryAnalyzer) -> Search:
                 Q('term', huisnummer=huisnummer)
             ],
         ),
-        sort_fields=['straatnaam.raw', 'huisnummer', 'toevoeging.keyword'],
+        sort_fields=[{'straatnaam.raw': {'unmapped_type': 'long'}}, 'huisnummer', 'toevoeging.keyword'],
         indexes=[NUMMERAANDUIDING],
         size=1
     )
@@ -261,7 +261,8 @@ def straatnaam_query(analyzer: QueryAnalyzer, features: int = 0) -> Search:
 
     return create_search_query(
         query=query,
-        sort_fields=['straatnaam.raw', 'huisnummer', 'toevoeging.keyword'],
+        sort_fields=[
+            {'straatnaam.raw': {'unmapped_type': 'long'}}, 'huisnummer', 'toevoeging.keyword'],
         indexes=[NUMMERAANDUIDING]
     )
 
@@ -280,7 +281,7 @@ def straatnaam_huisnummer_query(analyzer: QueryAnalyzer, features: int = 0) -> S
             'should': [
                 {
                     'match': {
-                        'straatnaam_keyword': straat
+                        'straatnaam_keyword': straat,
                     }
                 },
                 {
@@ -309,7 +310,8 @@ def straatnaam_huisnummer_query(analyzer: QueryAnalyzer, features: int = 0) -> S
 
     return create_search_query(
         query=query,
-        sort_fields=['_score', 'straatnaam.raw', 'huisnummer', 'toevoeging.keyword'],
+        sort_fields=['_score', 
+            {'straatnaam.raw': {'unmapped_type': 'long'}}, 'huisnummer', 'toevoeging.keyword'],
         indexes=[NUMMERAANDUIDING],
         search_type="dfs_query_then_fetch"
     )

--- a/bag/datasets/bag/queries.py
+++ b/bag/datasets/bag/queries.py
@@ -81,7 +81,7 @@ def bouwblok_query(analyzer: QueryAnalyzer, features: int = 0) -> Search:
                 "code": analyzer.get_bouwblok()
             },
         },
-        sort_fields=['code.keyword'],
+        sort_fields=[{'code.keyword': {'unmapped_type': 'long'}}],
         indexes=[BAG_BOUWBLOK],
     )
 
@@ -99,7 +99,7 @@ def postcode_query(analyzer: QueryAnalyzer, features: int = 0) -> Search:
                 Q('term', subtype='weg'),
             ],
         ),
-        sort_fields=['naam.keyword'],
+        sort_fields=[{'naam.keyword': {'unmapped_type': 'long'}}],
         indexes=[BAG_GEBIED]
     )
 

--- a/bag/datasets/brk/queries.py
+++ b/bag/datasets/brk/queries.py
@@ -79,7 +79,7 @@ def kadastraal_object_query(analyzer: QueryAnalyzer, features: int = 0) -> Searc
 
     return create_search_query(
         query=Q('bool', must=must),
-        sort_fields=['aanduiding.raw'],
+        sort_fields=[{'aanduiding.raw': {'unmapped_type': 'long'}}],
         indexes=[BRK_OBJECT],
     )
 
@@ -102,7 +102,7 @@ def kadastraal_subject_query(analyzer: QueryAnalyzer) -> Search:
                 Q('term', subtype='kadastraal_subject'),
             ]
         ),
-        sort_fields=['naam.raw'],
+        sort_fields=[{'naam.raw': {'unmapped_type': 'long'}}],
         indexes=[BRK_SUBJECT],
     )
 
@@ -130,6 +130,6 @@ def kadastraal_subject_nietnatuurlijk_query(
                 Q('term', subtype='kadastraal_subject'),
             ]
         ),
-        sort_fields=['naam.raw'],
+        sort_fields=[{'naam.raw': {'unmapped_type': 'long'}}],
         indexes=[BRK_SUBJECT],
     )


### PR DESCRIPTION
Because the bag data is now coming from another source (as minimally as possible from a Databricks pipeline), the elastic queries were failing. This PR makes them work again.