### PR TITLE
Add denormalize mgm cmd + config timeout elastic

### DIFF
--- a/bag/bag/settings/settings.py
+++ b/bag/bag/settings/settings.py
@@ -104,6 +104,8 @@ ELASTIC_INDICES = {
     'BAG_PAND': 'bag_v11_pand',
 }
 
+ELASTIC_INDEXING_TIMEOUT_SECONDS = int(os.getenv('ELASTIC_INDEXING_TIMEOUT_SECONDS', 60))
+
 TESTING = 'pytest' in sys.modules or (len(sys.argv) > 1 and sys.argv[1] == 'test')
 if TESTING:
     for k, v in ELASTIC_INDICES.items():

--- a/bag/bag_commands/management/commands/run_denormalize.py
+++ b/bag/bag_commands/management/commands/run_denormalize.py
@@ -1,0 +1,29 @@
+"""
+Database denormalize commands
+"""
+
+import sys
+
+from django.core.management import BaseCommand
+from django.db import connection
+
+import datasets.bag.batch
+import datasets.brk.batch
+from datasets import validate_tables
+from batch import batch
+
+
+class Command(BaseCommand):
+    """
+    denormalize data
+    """
+
+    def handle(self, *args, **options):
+
+        self.stdout.write("Denormalizing")
+        batch.execute(datasets.bag.batch.DenormalizeBagJob())
+
+        # analyze database after job
+        with connection.cursor() as cur:
+            self.stdout.write("Analyzing database...")
+            cur.execute("VACUUM ANALYZE")

--- a/bag/datasets/bag/batch.py
+++ b/bag/datasets/bag/batch.py
@@ -1536,6 +1536,19 @@ class ImportBagJob(batch.BasicJob):
             UpdateGrootstedelijkAttributenTask(),
         ]
 
+class DenormalizeBagJob(batch.BasicJob):
+    name = "Denormalize BAG data"
+
+
+    def tasks(self):
+
+        return [
+            # some sql copying fields
+            DenormalizeDataTask(),
+            # more denormalizing sql
+            UpdateGebiedenAttributenTask(),
+            UpdateGrootstedelijkAttributenTask(),
+        ]
 
 class IndexBagJob(batch.BasicJob):
     name = "Delete and Fill Nummeraanduiding search-index"

--- a/bag/search/index.py
+++ b/bag/search/index.py
@@ -122,7 +122,8 @@ class ImportIndexTask(object):
                 client,
                 self.convert_model_to_dict(qs),
                 raise_on_error=True,
-                refresh=True
+                refresh=True,
+                request_timeout=settings.ELASTIC_INDEXING_TIMEOUT_SECONDS
             )
 
         # When testing put all docs in one shard to make sure we have


### PR DESCRIPTION
Add separate mgm. command that does some denormalizations on of the BAG data.
Normally this was done after the import. However, import has been replaced by a Databricks pipeline.

Furthermore increased timeout for elastic indexing and made timeout configurable using an env var.