### PR TITLE
Tweak old index es script

### DIFF
--- a/bag/docker-index-es.sh
+++ b/bag/docker-index-es.sh
@@ -4,35 +4,16 @@ set -u   # crash on missing environment variables
 set -e   # stop on any error
 set -x   # log every command.
 
-trap "kill 0" EXIT
-
-source docker-wait.sh
-
 # clear elasticindices and creates empty ones
+# It seems that this step is essential to get the correct mapping
+# for the indexes!
 python manage.py elastic_indices --delete
 
 python manage.py elastic_indices gebieden pand --build
 
-python manage.py elastic_indices bag brk --partial=1/3 --build &
-python manage.py elastic_indices bag brk --partial=2/3 --build &
-python manage.py elastic_indices bag brk --partial=3/3 --build &
-
-
-FAIL=0
-
-for job in `jobs -p`
-do
-	echo $job
-	wait $job || let "FAIL+=1"
-done
-
-echo $FAIL
-
-if [ "$FAIL" == "0" ];
-then
-    echo "YAY!"
-else
-    echo "FAIL! ($FAIL)"
-    echo 'Elastic Import Error. 1 or more workers failed'
-    exit 1
-fi
+python manage.py elastic_indices bag --partial=1/3 --build 
+python manage.py elastic_indices bag --partial=2/3 --build 
+python manage.py elastic_indices bag --partial=3/3 --build 
+python manage.py elastic_indices brk --partial=1/3 --build 
+python manage.py elastic_indices brk --partial=2/3 --build 
+python manage.py elastic_indices brk --partial=3/3 --build 

--- a/bag/search/index.py
+++ b/bag/search/index.py
@@ -7,7 +7,7 @@ from django.db.models import BigIntegerField, F
 from django.db.models.functions import Cast
 from elasticsearch import helpers
 from elasticsearch.client import IndicesClient
-from elasticsearch.exceptions import NotFoundError
+from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticsearch_dsl.connections import connections
 
 from datasets.generic.database import count_qs
@@ -49,7 +49,13 @@ class DeleteIndexTask(object):
         for dt in self.doc_types:
             idx.doc_type(dt)
 
-        idx.create()
+        try:
+            idx.create()
+        except RequestError as e:
+            if 'resource_already_exists_exception' in str(e.info['error']):
+                pass
+            else:
+                raise
 
 
 class ImportIndexTask(object):


### PR DESCRIPTION
Tweak and re-use the bash script that was used on the cloudvps for re-indexing.
It turns out that the indexes need to be deleted and re-built in one go, otherwise indexes have incomplete mappings leading ot crippled search (esp. for postcode search).