### PR TITLE
Add deprecation warning to browsable interface

### DIFF
--- a/bag/datapunt_api/templates/rest_framework/api.html
+++ b/bag/datapunt_api/templates/rest_framework/api.html
@@ -17,6 +17,7 @@
 
 {% block description %}
     <div style="max-width: 50em; text-align: justify">
+    <div style="display: block;background: yellow;padding: 15px;width: -webkit-fill-available;border: solid orange 5px;">Waarschuwing: Dit is een verouderde API. Deze API wordt Oktober 2025 uitgeschakeld. Maak gebruik van de nieuwe API's op <a href="https://api.data.amsterdam.nl/v1">api.data.amsterdam.nl/v1</a></div>
     {{ description }}
     </div>
 {% endblock %}


### PR DESCRIPTION
De api gaat per oktober uit. Dit voegt deze melding toe aan alle browsable api pagina's in grote vriendelijke letters.